### PR TITLE
Add shared booking data store and modernize booking experience

### DIFF
--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -1,0 +1,242 @@
+import { randomUUID } from 'crypto';
+
+export type BookingStatus = 'confirmed' | 'cancelled' | 'completed';
+
+export interface Service {
+  id: string;
+  name: string;
+  description: string;
+  duration: number; // minutes
+  price: number; // dollars
+}
+
+export interface Therapist {
+  id: string;
+  name: string;
+  bio: string;
+  specialties: string[];
+  image: string;
+}
+
+export interface Booking {
+  id: string;
+  date: string; // ISO string representing start time
+  userName: string;
+  userEmail: string;
+  userPhone?: string;
+  serviceId: string;
+  therapistId: string;
+  status: BookingStatus;
+}
+
+const services: Service[] = [
+  {
+    id: '1',
+    name: 'Swedish Massage',
+    description:
+      'A gentle full-body massage that uses long strokes, kneading, and circular movements to relax and energise you.',
+    duration: 60,
+    price: 80,
+  },
+  {
+    id: '2',
+    name: 'Deep Tissue Massage',
+    description:
+      'Targets deeper muscle layers using slower, more forceful strokes. Ideal for chronic aches and tight muscles.',
+    duration: 60,
+    price: 95,
+  },
+  {
+    id: '3',
+    name: 'Hot Stone Massage',
+    description:
+      'Heated stones combined with therapeutic massage techniques melt away tension and ease sore muscles.',
+    duration: 90,
+    price: 125,
+  },
+  {
+    id: '4',
+    name: 'Aromatherapy Massage',
+    description:
+      'Essential oils tailored to your mood elevate a soothing massage focused on relaxation and stress relief.',
+    duration: 60,
+    price: 85,
+  },
+];
+
+const therapists: Therapist[] = [
+  {
+    id: '1',
+    name: 'Jane Smith',
+    bio: 'Over a decade of experience blending Swedish and Deep Tissue techniques for personalised treatments.',
+    specialties: ['Swedish Massage', 'Deep Tissue Massage'],
+    image: '/images/therapist1.jpg',
+  },
+  {
+    id: '2',
+    name: 'John Davis',
+    bio: 'Certified in hot stone therapy and aromatherapy with a passion for holistic wellbeing.',
+    specialties: ['Hot Stone Massage', 'Aromatherapy Massage'],
+    image: '/images/therapist2.jpg',
+  },
+  {
+    id: '3',
+    name: 'Sarah Johnson',
+    bio: 'Sports therapy specialist helping clients recover from injury and optimise performance.',
+    specialties: ['Sports Massage', 'Rehabilitation Therapy'],
+    image: '/images/therapist3.jpg',
+  },
+];
+
+let bookings: Booking[] = [
+  {
+    id: '1',
+    date: '2023-09-25T10:00:00.000Z',
+    userName: 'John Doe',
+    userEmail: 'john@example.com',
+    userPhone: '123-456-7890',
+    serviceId: '1',
+    therapistId: '1',
+    status: 'confirmed',
+  },
+];
+
+const BUSINESS_START_HOUR = 9;
+const BUSINESS_END_HOUR = 17;
+const SLOT_INTERVAL_MINUTES = 30;
+
+export const dataStore = {
+  getServices(): Service[] {
+    return services;
+  },
+
+  getServiceById(serviceId: string): Service | undefined {
+    return services.find((service) => service.id === serviceId);
+  },
+
+  getTherapists(): Therapist[] {
+    return therapists;
+  },
+
+  getTherapistById(therapistId: string): Therapist | undefined {
+    return therapists.find((therapist) => therapist.id === therapistId);
+  },
+
+  listBookings(): Booking[] {
+    return bookings;
+  },
+
+  getBookingById(id: string): Booking | undefined {
+    return bookings.find((booking) => booking.id === id);
+  },
+
+  createBooking(booking: Omit<Booking, 'id' | 'status'> & { status?: BookingStatus }): Booking {
+    const service = this.getServiceById(booking.serviceId);
+
+    if (!service) {
+      throw new Error('Service not found');
+    }
+
+    if (!this.isSlotAvailable(booking.date, booking.therapistId, service.duration)) {
+      throw new Error('Requested slot is no longer available');
+    }
+
+    const newBooking: Booking = {
+      ...booking,
+      id: randomUUID(),
+      status: booking.status ?? 'confirmed',
+    };
+
+    bookings = [...bookings, newBooking];
+    return newBooking;
+  },
+
+  updateBooking(id: string, updates: Partial<Omit<Booking, 'id'>>): Booking {
+    const existing = this.getBookingById(id);
+
+    if (!existing) {
+      throw new Error('Booking not found');
+    }
+
+    const next: Booking = { ...existing, ...updates };
+
+    if (updates.date || updates.therapistId || updates.serviceId) {
+      const service = this.getServiceById(next.serviceId);
+      if (!service) {
+        throw new Error('Service not found');
+      }
+
+      if (!this.isSlotAvailable(next.date, next.therapistId, service.duration, id)) {
+        throw new Error('Requested slot is no longer available');
+      }
+    }
+
+    bookings = bookings.map((booking) => (booking.id === id ? next : booking));
+    return next;
+  },
+
+  deleteBooking(id: string): void {
+    bookings = bookings.filter((booking) => booking.id !== id);
+  },
+
+  getAvailableSlots(dateIso: string, therapistId: string, serviceId: string): string[] {
+    const service = this.getServiceById(serviceId);
+
+    if (!service) {
+      throw new Error('Service not found');
+    }
+
+    const dayStart = new Date(`${dateIso}T00:00:00`);
+    if (Number.isNaN(dayStart.getTime())) {
+      throw new Error('Invalid date');
+    }
+
+    const start = new Date(dayStart);
+    start.setHours(BUSINESS_START_HOUR, 0, 0, 0);
+
+    const end = new Date(dayStart);
+    end.setHours(BUSINESS_END_HOUR, 0, 0, 0);
+
+    const durationMs = service.duration * 60 * 1000;
+    const intervalMs = SLOT_INTERVAL_MINUTES * 60 * 1000;
+
+    const availableSlots: string[] = [];
+
+    for (let slot = new Date(start); slot.getTime() + durationMs <= end.getTime(); slot = new Date(slot.getTime() + intervalMs)) {
+      const slotIso = slot.toISOString();
+      if (this.isSlotAvailable(slotIso, therapistId, service.duration)) {
+        availableSlots.push(slotIso);
+      }
+    }
+
+    return availableSlots;
+  },
+
+  isSlotAvailable(dateIso: string, therapistId: string, durationMinutes: number, ignoreBookingId?: string): boolean {
+    const slotStart = new Date(dateIso);
+    const slotEnd = new Date(slotStart.getTime() + durationMinutes * 60 * 1000);
+
+    return !bookings.some((booking) => {
+      if (booking.therapistId !== therapistId) {
+        return false;
+      }
+
+      if (ignoreBookingId && booking.id === ignoreBookingId) {
+        return false;
+      }
+
+      if (booking.status === 'cancelled') {
+        return false;
+      }
+
+      const bookingStart = new Date(booking.date);
+      const service = this.getServiceById(booking.serviceId);
+      const bookingDuration = service?.duration ?? durationMinutes;
+      const bookingEnd = new Date(bookingStart.getTime() + bookingDuration * 60 * 1000);
+
+      return slotStart < bookingEnd && slotEnd > bookingStart;
+    });
+  },
+};
+
+export type { Booking as BookingRecord };

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -139,7 +139,7 @@ export default function About() {
               </div>
               <h3 className="text-xl font-semibold mb-2">Client-Centered</h3>
               <p className="text-gray-600">
-                We put our clients' needs first, customizing each massage to address their specific concerns and preferences.
+                We put our clients’ needs first, customizing each massage to address their specific concerns and preferences.
               </p>
             </div>
             
@@ -165,7 +165,7 @@ export default function About() {
               </div>
               <h3 className="text-xl font-semibold mb-2">Convenience</h3>
               <p className="text-gray-600">
-                We make booking appointments easy and convenient, respecting our clients' time and schedules.
+                We make booking appointments easy and convenient, respecting our clients’ time and schedules.
               </p>
             </div>
           </div>

--- a/pages/api/bookings/[id].ts
+++ b/pages/api/bookings/[id].ts
@@ -1,76 +1,92 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
-// Mock database for demonstration purposes
-// In a real application, you would use a database like MongoDB, PostgreSQL, etc.
-let bookings = [
-  {
-    id: '1',
-    date: '2023-09-25T10:00:00Z',
-    userId: 'user1',
-    serviceId: 'service1',
-    therapistId: 'therapist1',
-    status: 'confirmed',
-    userName: 'John Doe',
-    userEmail: 'john@example.com',
-    userPhone: '123-456-7890',
-    serviceName: 'Swedish Massage',
-    serviceDuration: 60,
-    servicePrice: 80,
-    therapistName: 'Jane Smith'
-  }
-];
+import { BookingStatus, dataStore } from '@/lib/dataStore';
+
+type StoredBooking = ReturnType<typeof dataStore.listBookings>[number];
+
+const withDetails = (booking: StoredBooking) => {
+  const service = dataStore.getServiceById(booking.serviceId);
+  const therapist = dataStore.getTherapistById(booking.therapistId);
+
+  return {
+    ...booking,
+    serviceName: service?.name ?? 'Unknown Service',
+    serviceDuration: service?.duration ?? 60,
+    servicePrice: service?.price ?? 0,
+    therapistName: therapist?.name ?? 'Assigned Therapist',
+  };
+};
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;
-  
-  // Find the booking by ID
-  const bookingIndex = bookings.findIndex(booking => booking.id === id);
-  
-  if (bookingIndex === -1) {
+
+  if (typeof id !== 'string') {
+    return res.status(400).json({ error: 'Invalid booking identifier' });
+  }
+
+  const booking = dataStore.getBookingById(id);
+
+  if (!booking) {
     return res.status(404).json({ error: 'Booking not found' });
   }
-  
+
   if (req.method === 'GET') {
-    // Return the booking
-    return res.status(200).json(bookings[bookingIndex]);
-  } else if (req.method === 'PUT' || req.method === 'PATCH') {
-    // Update the booking
-    const { status, date, serviceId, therapistId } = req.body;
-    
-    // Check if the new slot is already booked (if changing date/therapist)
-    if (date && date !== bookings[bookingIndex].date || 
-        therapistId && therapistId !== bookings[bookingIndex].therapistId) {
-      
-      const isSlotBooked = bookings.some(
-        booking => 
-          booking.id !== id && // Exclude current booking
-          booking.date === (date || bookings[bookingIndex].date) && 
-          booking.therapistId === (therapistId || bookings[bookingIndex].therapistId) &&
-          booking.status === 'confirmed'
-      );
-      
-      if (isSlotBooked) {
-        return res.status(409).json({ error: 'This slot is already booked' });
-      }
-    }
-    
-    // Update the booking
-    bookings[bookingIndex] = {
-      ...bookings[bookingIndex],
-      ...(status && { status }),
-      ...(date && { date }),
-      ...(serviceId && { serviceId }),
-      ...(therapistId && { therapistId })
-    };
-    
-    return res.status(200).json(bookings[bookingIndex]);
-  } else if (req.method === 'DELETE') {
-    // Delete the booking
-    bookings = bookings.filter(booking => booking.id !== id);
-    
-    return res.status(200).json({ message: 'Booking deleted successfully' });
-  } else {
-    res.setHeader('Allow', ['GET', 'PUT', 'PATCH', 'DELETE']);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
+    return res.status(200).json(withDetails(booking));
   }
+
+  if (req.method === 'PUT' || req.method === 'PATCH') {
+    const { status, date, serviceId, therapistId } = req.body as Partial<{
+      status: BookingStatus;
+      date: string;
+      serviceId: string;
+      therapistId: string;
+    }>;
+
+    const updates: Partial<Omit<StoredBooking, 'id'>> = {};
+
+    if (status) {
+      const validStatuses: BookingStatus[] = ['confirmed', 'cancelled', 'completed'];
+      if (!validStatuses.includes(status)) {
+        return res.status(400).json({ error: 'Invalid booking status' });
+      }
+      updates.status = status;
+    }
+
+    if (date) {
+      const parsedDate = new Date(date);
+      if (Number.isNaN(parsedDate.getTime())) {
+        return res.status(400).json({ error: 'Invalid date supplied' });
+      }
+      updates.date = parsedDate.toISOString();
+    }
+
+    if (serviceId) {
+      updates.serviceId = serviceId;
+    }
+
+    if (therapistId) {
+      updates.therapistId = therapistId;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: 'No updates supplied' });
+    }
+
+    try {
+      const updated = dataStore.updateBooking(id, updates);
+      return res.status(200).json(withDetails(updated));
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unable to update booking';
+      const statusCode = message.includes('available') ? 409 : 400;
+      return res.status(statusCode).json({ error: message });
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    dataStore.deleteBooking(id);
+    return res.status(200).json({ message: 'Booking deleted successfully' });
+  }
+
+  res.setHeader('Allow', ['GET', 'PUT', 'PATCH', 'DELETE']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
 }

--- a/pages/api/bookings/available-slots.ts
+++ b/pages/api/bookings/available-slots.ts
@@ -1,75 +1,37 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
-// Mock database for demonstration purposes
-const bookings = [
-  {
-    id: '1',
-    date: '2023-09-25T10:00:00Z',
-    therapistId: '1',
-    status: 'confirmed'
-  },
-  {
-    id: '2',
-    date: '2023-09-25T14:00:00Z',
-    therapistId: '1',
-    status: 'confirmed'
-  },
-  {
-    id: '3',
-    date: '2023-09-25T11:00:00Z',
-    therapistId: '2',
-    status: 'confirmed'
-  }
-];
+import { dataStore } from '@/lib/dataStore';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'GET') {
-    const { date, therapistId, serviceId } = req.query;
-    
-    if (!date) {
-      return res.status(400).json({ error: 'Date parameter is required' });
-    }
-    
-    // Parse the date to get the day
-    const selectedDate = new Date(date as string);
-    const dayStart = new Date(selectedDate);
-    dayStart.setHours(0, 0, 0, 0);
-    
-    const dayEnd = new Date(selectedDate);
-    dayEnd.setHours(23, 59, 59, 999);
-    
-    // Business hours (9 AM to 5 PM)
-    const businessStart = 9; // 9 AM
-    const businessEnd = 17; // 5 PM
-    
-    // Generate all possible time slots for the day
-    const allSlots = [];
-    for (let hour = businessStart; hour < businessEnd; hour++) {
-      const slotTime = new Date(dayStart);
-      slotTime.setHours(hour);
-      allSlots.push(slotTime.toISOString());
-    }
-    
-    // Filter out booked slots for the selected therapist
-    const bookedSlots = bookings
-      .filter(booking => 
-        booking.status === 'confirmed' && 
-        (!therapistId || booking.therapistId === therapistId) &&
-        new Date(booking.date) >= dayStart && 
-        new Date(booking.date) <= dayEnd
-      )
-      .map(booking => booking.date);
-    
-    // Available slots are all slots minus booked slots
-    const availableSlots = allSlots.filter(slot => !bookedSlots.includes(slot));
-    
-    return res.status(200).json({
-      date: date,
-      therapistId: therapistId || 'any',
-      availableSlots: availableSlots
-    });
-  } else {
+  if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { date, therapistId, serviceId } = req.query;
+
+  if (typeof date !== 'string' || date.length === 0) {
+    return res.status(400).json({ error: 'Date parameter is required' });
+  }
+
+  if (typeof therapistId !== 'string' || therapistId.length === 0) {
+    return res.status(400).json({ error: 'Therapist parameter is required' });
+  }
+
+  if (typeof serviceId !== 'string' || serviceId.length === 0) {
+    return res.status(400).json({ error: 'Service parameter is required' });
+  }
+
+  try {
+    const availableSlots = dataStore.getAvailableSlots(date, therapistId, serviceId);
+    return res.status(200).json({
+      date,
+      therapistId,
+      serviceId,
+      availableSlots,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unable to determine available slots';
+    return res.status(400).json({ error: message });
   }
 }

--- a/pages/api/bookings/index.ts
+++ b/pages/api/bookings/index.ts
@@ -1,86 +1,58 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
-// Mock database for demonstration purposes
-// In a real application, you would use a database like MongoDB, PostgreSQL, etc.
-let bookings = [
-  {
-    id: '1',
-    date: '2023-09-25T10:00:00Z',
-    userId: 'user1',
-    serviceId: 'service1',
-    therapistId: 'therapist1',
-    status: 'confirmed',
-    userName: 'John Doe',
-    userEmail: 'john@example.com',
-    userPhone: '123-456-7890',
-    serviceName: 'Swedish Massage',
-    serviceDuration: 60,
-    servicePrice: 80,
-    therapistName: 'Jane Smith'
-  }
-];
+import { dataStore } from '@/lib/dataStore';
+
+type StoredBooking = ReturnType<typeof dataStore.listBookings>[number];
+
+const withDetails = (booking: StoredBooking) => {
+  const service = dataStore.getServiceById(booking.serviceId);
+  const therapist = dataStore.getTherapistById(booking.therapistId);
+
+  return {
+    ...booking,
+    serviceName: service?.name ?? 'Unknown Service',
+    serviceDuration: service?.duration ?? 60,
+    servicePrice: service?.price ?? 0,
+    therapistName: therapist?.name ?? 'Assigned Therapist',
+  };
+};
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    // Return all bookings
-    return res.status(200).json(bookings);
-  } else if (req.method === 'POST') {
-    // Create a new booking
-    const { date, userId, serviceId, therapistId, userName, userEmail, userPhone } = req.body;
-    
-    // Validate required fields
-    if (!date || !userName || !userEmail) {
+    const records = dataStore.listBookings().map((booking) => withDetails(booking));
+    return res.status(200).json(records);
+  }
+
+  if (req.method === 'POST') {
+    const { date, serviceId, therapistId, userName, userEmail, userPhone } = req.body;
+
+    if (!date || !serviceId || !therapistId || !userName || !userEmail) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
-    
-    // Check if the slot is already booked
-    const isSlotBooked = bookings.some(
-      booking => 
-        booking.date === date && 
-        booking.therapistId === therapistId &&
-        booking.status === 'confirmed'
-    );
-    
-    if (isSlotBooked) {
-      return res.status(409).json({ error: 'This slot is already booked' });
+
+    const parsedDate = new Date(date);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return res.status(400).json({ error: 'Invalid date supplied' });
     }
-    
-    // Mock service and therapist data
-    // In a real application, you would fetch this from your database
-    const service = {
-      id: serviceId,
-      name: 'Swedish Massage',
-      duration: 60,
-      price: 80
-    };
-    
-    const therapist = {
-      id: therapistId,
-      name: 'Jane Smith'
-    };
-    
-    // Create a new booking
-    const newBooking = {
-      id: String(bookings.length + 1),
-      date,
-      userId,
-      serviceId,
-      therapistId,
-      status: 'confirmed',
-      userName,
-      userEmail,
-      userPhone,
-      serviceName: service.name,
-      serviceDuration: service.duration,
-      servicePrice: service.price,
-      therapistName: therapist.name
-    };
-    
-    bookings.push(newBooking);
-    
-    return res.status(201).json(newBooking);
-  } else {
-    res.setHeader('Allow', ['GET', 'POST']);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
+
+    try {
+      const booking = dataStore.createBooking({
+        date: parsedDate.toISOString(),
+        serviceId,
+        therapistId,
+        userName,
+        userEmail,
+        userPhone,
+      });
+
+      return res.status(201).json(withDetails(booking));
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unable to create booking';
+      const status = message.includes('available') ? 409 : 400;
+      return res.status(status).json({ error: message });
+    }
   }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
 }

--- a/pages/api/services/index.ts
+++ b/pages/api/services/index.ts
@@ -1,43 +1,12 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
-// Mock database for demonstration purposes
-const services = [
-  {
-    id: '1',
-    name: 'Swedish Massage',
-    description: 'A gentle form of massage that uses long strokes, kneading, deep circular movements, vibration and tapping.',
-    duration: 60,
-    price: 80
-  },
-  {
-    id: '2',
-    name: 'Deep Tissue Massage',
-    description: 'A massage technique that focuses on the deeper layers of muscle tissue.',
-    duration: 60,
-    price: 90
-  },
-  {
-    id: '3',
-    name: 'Hot Stone Massage',
-    description: 'A specialty massage where the therapist uses smooth, heated stones as an extension of their own hands.',
-    duration: 90,
-    price: 120
-  },
-  {
-    id: '4',
-    name: 'Aromatherapy Massage',
-    description: 'A massage therapy that uses essential oils to enhance the massage experience.',
-    duration: 60,
-    price: 85
-  }
-];
+import { dataStore } from '@/lib/dataStore';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    // Return all services
-    return res.status(200).json(services);
-  } else {
-    res.setHeader('Allow', ['GET']);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
+    return res.status(200).json(dataStore.getServices());
   }
+
+  res.setHeader('Allow', ['GET']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
 }

--- a/pages/api/therapists/index.ts
+++ b/pages/api/therapists/index.ts
@@ -1,36 +1,12 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
-// Mock database for demonstration purposes
-const therapists = [
-  {
-    id: '1',
-    name: 'Jane Smith',
-    bio: 'Jane has 10+ years of experience in various massage techniques, specializing in Swedish and Deep Tissue massage.',
-    specialties: ['Swedish Massage', 'Deep Tissue Massage'],
-    image: '/images/therapist1.jpg'
-  },
-  {
-    id: '2',
-    name: 'John Davis',
-    bio: 'John is certified in Hot Stone and Aromatherapy massage with 5 years of experience in luxury spas.',
-    specialties: ['Hot Stone Massage', 'Aromatherapy Massage'],
-    image: '/images/therapist2.jpg'
-  },
-  {
-    id: '3',
-    name: 'Sarah Johnson',
-    bio: 'Sarah specializes in sports massage and rehabilitation therapy, helping athletes recover from injuries.',
-    specialties: ['Sports Massage', 'Rehabilitation Therapy'],
-    image: '/images/therapist3.jpg'
-  }
-];
+import { dataStore } from '@/lib/dataStore';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    // Return all therapists
-    return res.status(200).json(therapists);
-  } else {
-    res.setHeader('Allow', ['GET']);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
+    return res.status(200).json(dataStore.getTherapists());
   }
+
+  res.setHeader('Allow', ['GET']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
 }

--- a/pages/booking-new.tsx
+++ b/pages/booking-new.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { useRouter } from 'next/router';
@@ -19,9 +19,19 @@ interface Therapist {
   image: string;
 }
 
-interface TimeSlot {
-  time: Date;
-  available: boolean;
+interface BookingResponse {
+  id: string;
+  date: string;
+  userName: string;
+  userEmail: string;
+  userPhone?: string;
+  serviceId: string;
+  therapistId: string;
+  status: string;
+  serviceName: string;
+  serviceDuration: number;
+  servicePrice: number;
+  therapistName: string;
 }
 
 export default function BookingNew() {
@@ -43,7 +53,17 @@ export default function BookingNew() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [bookingConfirmed, setBookingConfirmed] = useState<boolean>(false);
-  const [bookingId, setBookingId] = useState<string | null>(null);
+  const [bookingDetails, setBookingDetails] = useState<BookingResponse | null>(null);
+
+  const selectedServiceDetails = useMemo(
+    () => services.find((service) => service.id === selectedService) ?? null,
+    [services, selectedService]
+  );
+
+  const selectedTherapistDetails = useMemo(
+    () => therapists.find((therapist) => therapist.id === selectedTherapist) ?? null,
+    [therapists, selectedTherapist]
+  );
 
   // Fetch services and therapists on component mount
   useEffect(() => {
@@ -67,25 +87,22 @@ export default function BookingNew() {
     fetchData();
   }, []);
 
-  // Fetch available slots when date or therapist changes
-  useEffect(() => {
-    if (selectedDate && selectedTherapist) {
-      fetchAvailableSlots();
-    }
-  }, [selectedDate, selectedTherapist]);
-
-  const fetchAvailableSlots = async () => {
+  const fetchAvailableSlots = useCallback(async () => {
     setIsLoading(true);
     try {
+      if (!selectedService || !selectedTherapist) {
+        return;
+      }
+
       const dateString = selectedDate.toISOString().split('T')[0];
       const response = await fetch(
-        `/api/bookings/available-slots?date=${dateString}&therapistId=${selectedTherapist}`
+        `/api/bookings/available-slots?date=${dateString}&therapistId=${selectedTherapist}&serviceId=${selectedService}`
       );
-      
+
       if (!response.ok) {
         throw new Error('Failed to fetch available slots');
       }
-      
+
       const data = await response.json();
       setAvailableSlots(data.availableSlots);
       setError(null);
@@ -95,7 +112,21 @@ export default function BookingNew() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [selectedDate, selectedService, selectedTherapist]);
+
+  // Fetch available slots when date or therapist changes
+  useEffect(() => {
+    if (selectedService && selectedTherapist) {
+      fetchAvailableSlots();
+    } else {
+      setAvailableSlots([]);
+      setError(null);
+    }
+  }, [fetchAvailableSlots, selectedService, selectedTherapist]);
+
+  useEffect(() => {
+    setSelectedTime(null);
+  }, [selectedDate, selectedTherapist, selectedService]);
 
   const handleBooking = async () => {
     if (!selectedService || !selectedTherapist || !selectedDate || !selectedTime) {
@@ -130,9 +161,10 @@ export default function BookingNew() {
         throw new Error(errorData.error || 'Failed to create booking');
       }
       
-      const bookingData = await response.json();
-      setBookingId(bookingData.id);
+      const bookingData: BookingResponse = await response.json();
+      setBookingDetails(bookingData);
       setBookingConfirmed(true);
+      setAvailableSlots((slots) => slots.filter((slot) => slot !== bookingData.date));
       setError(null);
     } catch (err: any) {
       console.error('Error creating booking:', err);
@@ -148,17 +180,18 @@ export default function BookingNew() {
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   };
 
-  if (bookingConfirmed) {
+  if (bookingConfirmed && bookingDetails) {
+    const scheduledDate = new Date(bookingDetails.date);
     return (
       <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded-lg shadow-xl">
         <h2 className="text-2xl font-bold text-green-600 mb-4">Booking Confirmed!</h2>
-        <p>Thank you for booking with us, {userInfo.name}.</p>
+        <p>Thank you for booking with us, {bookingDetails.userName}.</p>
         <p className="mt-2">
-          Your {services.find(s => s.id === selectedService)?.name} is scheduled for{' '}
-          {selectedDate.toLocaleDateString()} at {formatTime(selectedTime || '')}.
+          Your {bookingDetails.serviceName} is scheduled for{' '}
+          {scheduledDate.toLocaleDateString()} at {formatTime(bookingDetails.date)}.
         </p>
-        <p className="mt-4">A confirmation email has been sent to {userInfo.email}.</p>
-        <p className="mt-2">Your booking reference number is: {bookingId}</p>
+        <p className="mt-4">A confirmation email has been sent to {bookingDetails.userEmail}.</p>
+        <p className="mt-2">Your booking reference number is: {bookingDetails.id}</p>
         <button
           onClick={() => router.push('/')}
           className="mt-6 w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -184,7 +217,7 @@ export default function BookingNew() {
           <h2 className="text-xl font-semibold mb-4">1. Select Service</h2>
           <div className="space-y-2">
             {services.map(service => (
-              <div 
+              <div
                 key={service.id}
                 className={`p-4 border rounded cursor-pointer ${
                   selectedService === service.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
@@ -201,7 +234,7 @@ export default function BookingNew() {
           <h2 className="text-xl font-semibold mt-6 mb-4">2. Select Therapist</h2>
           <div className="space-y-2">
             {therapists.map(therapist => (
-              <div 
+              <div
                 key={therapist.id}
                 className={`p-4 border rounded cursor-pointer ${
                   selectedTherapist === therapist.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
@@ -261,7 +294,26 @@ export default function BookingNew() {
             className="w-full"
           />
           
-          <h3 className="font-medium mt-4 mb-2">Available Times</h3>
+          <div className="mt-4 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-600">
+            <p className="font-medium text-gray-700">Summary</p>
+            {selectedServiceDetails ? (
+              <p>
+                {selectedServiceDetails.name} &middot; {selectedServiceDetails.duration} minutes &middot; ${selectedServiceDetails.price}
+              </p>
+            ) : (
+              <p>Select a service to see duration and price.</p>
+            )}
+            {selectedTherapistDetails && (
+              <p>Therapist: {selectedTherapistDetails.name}</p>
+            )}
+            {selectedTime && (
+              <p>
+                Appointment: {selectedDate.toLocaleDateString()} at {formatTime(selectedTime)}
+              </p>
+            )}
+          </div>
+
+          <h3 className="font-medium mt-6 mb-2">Available Times</h3>
           {isLoading ? (
             <div className="text-center py-4">Loading available slots...</div>
           ) : availableSlots.length > 0 ? (

--- a/pages/index-new.tsx
+++ b/pages/index-new.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unescaped-entities */
 import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,57 +1,120 @@
-import { useState } from 'react';
+import Head from 'next/head';
 import Link from 'next/link';
 
+const features = [
+  {
+    title: 'Licensed Therapists',
+    description: 'Every practitioner is fully certified and specialised in a range of restorative treatments.',
+  },
+  {
+    title: 'Tailored Treatments',
+    description: 'Select the service, therapist, date, and time that suits your body and schedule best.',
+  },
+  {
+    title: 'Secure & Seamless',
+    description: 'Our modern booking flow keeps your data safe while reserving appointments in seconds.',
+  },
+];
+
 export default function Home() {
-    const [menuVisible, setMenuVisible] = useState<boolean>(false);
+  return (
+    <>
+      <Head>
+        <title>Serenity Massage Studio</title>
+        <meta
+          name="description"
+          content="Book rejuvenating massage appointments with licensed therapists in just a few clicks."
+        />
+      </Head>
 
-    return (
-        <>
-            <div>
-                <h1 className="Title text-center font-semibold text-3xl">Welcome to Home Page</h1>
+      <div className="min-h-screen bg-gradient-to-b from-blue-50 via-white to-white">
+        <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
+          <div className="text-2xl font-bold text-blue-700">Serenity</div>
+          <nav className="hidden space-x-6 text-sm font-medium text-gray-700 md:flex">
+            <Link href="/services" className="hover:text-blue-600">
+              Services
+            </Link>
+            <Link href="/about" className="hover:text-blue-600">
+              About
+            </Link>
+            <Link href="/admin" className="hover:text-blue-600">
+              Admin
+            </Link>
+          </nav>
+          <Link
+            href="/booking-new"
+            className="rounded-full bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-600/30 transition hover:bg-blue-700"
+          >
+            Book now
+          </Link>
+        </header>
+
+        <main className="mx-auto flex max-w-6xl flex-col gap-16 px-6 pb-16 pt-12 md:flex-row md:items-center">
+          <div className="flex-1 space-y-6">
+            <p className="inline-flex items-center rounded-full bg-blue-100 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-blue-800">
+              Restore. Relax. Renew.
+            </p>
+            <h1 className="text-4xl font-bold text-gray-900 md:text-5xl">
+              Reserve a personalised massage in minutes
+            </h1>
+            <p className="text-lg text-gray-600">
+              Choose your preferred service, therapist, and appointment time. Our real-time availability keeps your schedule
+              organised and ensures every visit is effortless.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/booking-new"
+                className="inline-flex items-center justify-center rounded-full bg-blue-600 px-6 py-3 font-semibold text-white shadow-md transition hover:bg-blue-700"
+              >
+                Start booking
+              </Link>
+              <Link
+                href="/services"
+                className="inline-flex items-center justify-center rounded-full border border-blue-200 px-6 py-3 font-semibold text-blue-700 transition hover:border-blue-400 hover:text-blue-800"
+              >
+                Explore services
+              </Link>
             </div>
-            <div className="p-8 flex">
-                <div className="mr-8">
-                    <button className="p-2" onClick={() => setMenuVisible(!menuVisible)}>
-                        {/* SVG for the hamburger icon */}
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-6 w-6">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16m-7 6h7"></path>
-                        </svg>
-                    </button>
+          </div>
 
-                    {menuVisible && (
-                        <div className="mt-4 bg-gray-100 rounded p-4">
-                            <ul>
-                                <li className="mb-2">
-                                    <Link href="/" className="text-gray-700 hover:font-bold">
-                                        Home
-                                    </Link>
-                                </li>
-                                <li className="mb-2">
-                                    <Link href="/booking" className="text-gray-700 hover:font-bold">
-                                        Booking
-                                    </Link>
-                                </li>
-                                <li className="mb-2">
-                                    <Link href="/booking2" className="text-gray-700 hover:font-bold">
-                                        Booking2
-                                    </Link>
-                                </li>
-                                <li className="mb-2">
-                                    <Link href="#" className="text-gray-700 hover:font-bold">
-                                        Benefits
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link href="#" className="text-gray-700 hover:font-bold">
-                                        About Us
-                                    </Link>
-                                </li>
-                            </ul>
-                        </div>
-                    )}
+          <div className="flex-1">
+            <div className="rounded-3xl bg-white p-6 shadow-xl shadow-blue-100">
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold text-gray-900">Next available appointments</h2>
+                <div className="space-y-3 text-sm text-gray-600">
+                  <p>
+                    <span className="font-medium text-gray-900">Swedish Massage</span> — today at 3:00 PM with Jane Smith
+                  </p>
+                  <p>
+                    <span className="font-medium text-gray-900">Deep Tissue</span> — tomorrow at 10:00 AM with Sarah Johnson
+                  </p>
+                  <p>
+                    <span className="font-medium text-gray-900">Hot Stone</span> — Thursday at 4:00 PM with John Davis
+                  </p>
                 </div>
+                <Link href="/booking-new" className="mt-4 inline-flex text-sm font-semibold text-blue-600 hover:text-blue-700">
+                  View schedule →
+                </Link>
+              </div>
             </div>
-        </>
-    );
+          </div>
+        </main>
+
+        <section className="bg-white py-16">
+          <div className="mx-auto max-w-6xl px-6">
+            <h2 className="text-center text-3xl font-bold text-gray-900">Why guests choose Serenity</h2>
+            <div className="mt-10 grid gap-8 md:grid-cols-3">
+              {features.map((feature) => (
+                <div key={feature.title} className="rounded-2xl border border-gray-100 bg-gray-50 p-6 shadow-sm">
+                  <h3 className="text-xl font-semibold text-gray-900">{feature.title}</h3>
+                  <p className="mt-3 text-sm text-gray-600">{feature.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </>
+  );
 }
 

--- a/pages/services.tsx
+++ b/pages/services.tsx
@@ -201,7 +201,7 @@ export default function Services() {
             <div className="bg-white p-6 rounded-lg shadow-md">
               <h3 className="text-xl font-semibold mb-2">What should I wear during a massage?</h3>
               <p className="text-gray-600">
-                You'll be properly draped during the session. Undress to your comfort level. Many clients prefer to remove most clothing, 
+                You’ll be properly draped during the session. Undress to your comfort level. Many clients prefer to remove most clothing,
                 but you can keep underwear on if you prefer. The therapist will leave the room while you undress and get on the table.
               </p>
             </div>
@@ -209,8 +209,8 @@ export default function Services() {
             <div className="bg-white p-6 rounded-lg shadow-md">
               <h3 className="text-xl font-semibold mb-2">How do I choose the right massage type?</h3>
               <p className="text-gray-600">
-                Consider your goals: relaxation, pain relief, or stress reduction. Swedish massage is great for beginners and relaxation. 
-                Deep tissue is better for chronic pain. If you're unsure, our therapists can help recommend the best option for your needs.
+                Consider your goals: relaxation, pain relief, or stress reduction. Swedish massage is great for beginners and relaxation.
+                Deep tissue is better for chronic pain. If you’re unsure, our therapists can help recommend the best option for your needs.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- create a shared in-memory data store for services, therapists, and bookings with availability calculation helpers
- update booking-related API routes to use the shared store and enforce validation for slot availability and status updates
- refresh the booking flow UI and homepage hero while addressing lingering lint warnings on legacy pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4d09c00d48324b3db2e589b8f3b51